### PR TITLE
Updated %d to %@ when formatting the bookmark ID

### DIFF
--- a/InstapaperKit/IKBookmark.m
+++ b/InstapaperKit/IKBookmark.m
@@ -59,9 +59,9 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %@ (%@), URL:(%@)>", NSStringFromClass([self class]),
+    return [NSString stringWithFormat:@"<%@: %@ (%ld), URL:(%@)>", NSStringFromClass([self class]),
                                                                   self.title,
-                                                                  self.bookmarkID,
+                                                                  (long)self.bookmarkID,
                                                                   self.URL];
 }
 

--- a/InstapaperKit/IKBookmark.m
+++ b/InstapaperKit/IKBookmark.m
@@ -59,7 +59,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %@ (%d), URL:(%@)>", NSStringFromClass([self class]),
+    return [NSString stringWithFormat:@"<%@: %@ (%@), URL:(%@)>", NSStringFromClass([self class]),
                                                                   self.title,
                                                                   self.bookmarkID,
                                                                   self.URL];

--- a/InstapaperKit/IKEngine.m
+++ b/InstapaperKit/IKEngine.m
@@ -151,7 +151,7 @@ static NSString *_OAuthConsumerSecret = nil;
     NSMutableString *have = [NSMutableString string];
     if ([bookmarks count] > 0) {
         for (IKBookmark *bookmark in bookmarks) {
-            [have appendFormat:@"%@", bookmark.bookmarkID];
+            [have appendFormat:@"%ld", (long)bookmark.bookmarkID];
             if (bookmark.hashString) {
                 [have appendFormat:@":%@", bookmark.hashString];
             }

--- a/InstapaperKit/IKEngine.m
+++ b/InstapaperKit/IKEngine.m
@@ -151,9 +151,9 @@ static NSString *_OAuthConsumerSecret = nil;
     NSMutableString *have = [NSMutableString string];
     if ([bookmarks count] > 0) {
         for (IKBookmark *bookmark in bookmarks) {
-            [have appendFormat:@"%d", bookmark.bookmarkID];
-            if (bookmark.hash) {
-                [have appendFormat:@":%@", bookmark.hash];
+            [have appendFormat:@"%@", bookmark.bookmarkID];
+            if (bookmark.hashString) {
+                [have appendFormat:@":%@", bookmark.hashString];
             }
             if (bookmark.progressDate && bookmark.progress != -1.0f) {
                 int timestamp = (int)[bookmark.progressDate timeIntervalSince1970];


### PR DESCRIPTION
I found that when using %d the wrong value was being output. I noted from documentation that on a 64-bit build the NSInteger would be 64 bits in size, whereas for a 32-bit build NSInteger is just 32 bits in size.

Using %@ to "print" the NSInteger seemed to work fine - it actually gave me a representation that matched the values on instapaper.com. Can you try this out and see if it works for you?

I also fixed the calls to bookmark.hash as I suspect that should have been bookmark.hashString.

Cheers,

Maurice
