### PR TITLE
Added ability to retrieve folder ID from engine:connection:didReceiveBookmarks:ofUser: message

### DIFF
--- a/InstapaperKit/IKEngine.h
+++ b/InstapaperKit/IKEngine.h
@@ -38,7 +38,7 @@
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveAuthToken:(NSString *)token andTokenSecret:(NSString *)secret;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didVerifyCredentialsForUser:(IKUser *)user;
 
-- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user;
+- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user forFolder:(IKFolder *)folder;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didUpdateReadProgressOfBookmark:(IKBookmark *)bookmark;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didAddBookmark:(IKBookmark *)bookmark;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didDeleteBookmarkWithBookmarkID:(NSInteger)bookmarkID;

--- a/InstapaperKit/IKEngine.m
+++ b/InstapaperKit/IKEngine.m
@@ -173,7 +173,7 @@ static NSString *_OAuthConsumerSecret = nil;
                                bodyArguments:arguments
                                         type:IKURLConnectionTypeBookmarksList
                                     userInfo:userInfo
-                                     context:nil];
+                                     context:folder];
 }
 
 - (NSString *)updateReadProgressOfBookmark:(IKBookmark *)bookmark toProgress:(CGFloat)progress userInfo:(id)userInfo
@@ -513,9 +513,12 @@ static NSString *_OAuthConsumerSecret = nil;
                     }
                 }
                 
+                //  Retrieve folder ID from connection context
+                IKFolder *folder = (IKFolder *)[connection _context];
+                
                 // Inform delegate
-                if ([self.delegate respondsToSelector:@selector(engine:connection:didReceiveBookmarks:ofUser:)]) {
-                    [self.delegate engine:self connection:connection didReceiveBookmarks:bookmarks ofUser:user];
+                if ([self.delegate respondsToSelector:@selector(engine:connection:didReceiveBookmarks:ofUser:forFolder:)]) {
+                    [self.delegate engine:self connection:connection didReceiveBookmarks:bookmarks ofUser:user forFolder:folder];
                 }
                 break;
             }

--- a/Test/TestAppDelegate.m
+++ b/Test/TestAppDelegate.m
@@ -113,9 +113,9 @@
     NSLog(@"engine %@ connection %@ did verify credentials for user %@", engine, connection, user);
 }
 
-- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user
+- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user forFolder:(IKFolder *)folder
 {
-    NSLog(@"engine %@ connection %@ did receive bookmarks %@ of user %@", engine, connection, bookmarks, user);
+    NSLog(@"engine %@ connection %@ did receive bookmarks %@ of user %@ for folder %@", engine, connection, bookmarks, user, folder);
 }
 
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didUpdateReadProgressOfBookmark:(IKBookmark *)bookmark


### PR DESCRIPTION
Stores the folder ID in the context of the IKURLConnection object. This is extracted when the results are being processed and is passed to the delegate method so that the calling code can obtain it.

I couldn't find a way to to determine which folder the bookmarks were from otherwise.
