### PR TITLE
Filled out the extra details of the Unread, Liked and Archive folders

### DIFF
--- a/InstapaperKit/IKDeserializer.m
+++ b/InstapaperKit/IKDeserializer.m
@@ -112,6 +112,7 @@
             user.subscribed = [[self _normalizedObjectForKey:@"subscription_is_active" inDictionary:dict] boolValue];
             
             [result addObject:user];
+            [user release];
             
         } else if ([type isEqualToString:@"bookmark"]) {
             // Create bookmark object
@@ -129,6 +130,7 @@
             bookmark.progressDate  = [self _dateForKey:@"progress_timestamp" inDictionary:dict];
             
             [result addObject:bookmark];
+            [bookmark release];
 
         } else if ([type isEqualToString:@"folder"]) {
             // Create folder object
@@ -140,6 +142,7 @@
             folder.position     = [[self _normalizedObjectForKey:@"position" inDictionary:dict] unsignedIntegerValue];
             
             [result addObject:folder];
+            [folder release];
             
         }
     }

--- a/InstapaperKit/IKDeserializer.m
+++ b/InstapaperKit/IKDeserializer.m
@@ -144,6 +144,12 @@
             [result addObject:folder];
             [folder release];
             
+        } else if ([type isEqualToString:@"meta"]) {
+            NSString *deleteIDsAsString = [self _normalizedObjectForKey:@"delete_ids" inDictionary:dict];
+            if (deleteIDsAsString) {
+                NSArray *deleteIDs = [deleteIDsAsString componentsSeparatedByString:@","];
+                [result addObject:deleteIDs];
+            }
         }
     }
     

--- a/InstapaperKit/IKEngine.h
+++ b/InstapaperKit/IKEngine.h
@@ -38,7 +38,7 @@
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveAuthToken:(NSString *)token andTokenSecret:(NSString *)secret;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didVerifyCredentialsForUser:(IKUser *)user;
 
-- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user;
+- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user forFolder:(IKFolder *)folder;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didUpdateReadProgressOfBookmark:(IKBookmark *)bookmark;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didAddBookmark:(IKBookmark *)bookmark;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didDeleteBookmarkWithBookmarkID:(NSInteger)bookmarkID;

--- a/InstapaperKit/IKEngine.h
+++ b/InstapaperKit/IKEngine.h
@@ -38,7 +38,7 @@
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveAuthToken:(NSString *)token andTokenSecret:(NSString *)secret;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didVerifyCredentialsForUser:(IKUser *)user;
 
-- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user forFolder:(IKFolder *)folder;
+- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user forFolder:(IKFolder *)folder withDeleteIDs:(NSArray *)deleteIDs;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didUpdateReadProgressOfBookmark:(IKBookmark *)bookmark;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didAddBookmark:(IKBookmark *)bookmark;
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didDeleteBookmarkWithBookmarkID:(NSInteger)bookmarkID;

--- a/InstapaperKit/IKEngine.m
+++ b/InstapaperKit/IKEngine.m
@@ -173,7 +173,7 @@ static NSString *_OAuthConsumerSecret = nil;
                                bodyArguments:arguments
                                         type:IKURLConnectionTypeBookmarksList
                                     userInfo:userInfo
-                                     context:nil];
+                                     context:folder];
 }
 
 - (NSString *)updateReadProgressOfBookmark:(IKBookmark *)bookmark toProgress:(CGFloat)progress userInfo:(id)userInfo
@@ -513,9 +513,12 @@ static NSString *_OAuthConsumerSecret = nil;
                     }
                 }
                 
+                //  Retrieve folder ID from connection context
+                IKFolder *folder = (IKFolder *)[connection _context];
+                
                 // Inform delegate
-                if ([self.delegate respondsToSelector:@selector(engine:connection:didReceiveBookmarks:ofUser:)]) {
-                    [self.delegate engine:self connection:connection didReceiveBookmarks:bookmarks ofUser:user];
+                if ([self.delegate respondsToSelector:@selector(engine:connection:didReceiveBookmarks:ofUser:forFolder:)]) {
+                    [self.delegate engine:self connection:connection didReceiveBookmarks:bookmarks ofUser:user forFolder:folder];
                 }
                 break;
             }

--- a/InstapaperKit/IKEngine.m
+++ b/InstapaperKit/IKEngine.m
@@ -505,11 +505,14 @@ static NSString *_OAuthConsumerSecret = nil;
                 // Get objects from array
                 IKUser *user = nil;
                 NSMutableArray *bookmarks = [NSMutableArray array];
+                NSArray *deleteIDs = nil;
                 for (id object in result) {
                     if ([object isKindOfClass:[IKUser class]]) {
                         user = (IKUser *)object;
                     } else if ([object isKindOfClass:[IKBookmark class]]) {
                         [bookmarks addObject:object];
+                    } else if ([object isKindOfClass:[NSArray class]]) {
+                        deleteIDs = (NSArray *)object;
                     }
                 }
                 
@@ -517,8 +520,8 @@ static NSString *_OAuthConsumerSecret = nil;
                 IKFolder *folder = (IKFolder *)[connection _context];
                 
                 // Inform delegate
-                if ([self.delegate respondsToSelector:@selector(engine:connection:didReceiveBookmarks:ofUser:forFolder:)]) {
-                    [self.delegate engine:self connection:connection didReceiveBookmarks:bookmarks ofUser:user forFolder:folder];
+                if ([self.delegate respondsToSelector:@selector(engine:connection:didReceiveBookmarks:ofUser:forFolder:withDeleteIDs:)]) {
+                    [self.delegate engine:self connection:connection didReceiveBookmarks:bookmarks ofUser:user forFolder:folder withDeleteIDs:deleteIDs];
                 }
                 break;
             }

--- a/InstapaperKit/IKFolder.m
+++ b/InstapaperKit/IKFolder.m
@@ -32,17 +32,26 @@
 
 + (IKFolder *)unreadFolder
 {
-    return [self folderWithFolderID:IKUnreadFolderID];
+    IKFolder * newFolder = [self folderWithFolderID:IKUnreadFolderID];
+    newFolder.title = @"Read Later";
+    newFolder.position = 0;
+    return newFolder;
 }
 
 + (IKFolder *)starredFolder
 {
-    return [self folderWithFolderID:IKStarredFolderID];
+    IKFolder * newFolder = [self folderWithFolderID:IKStarredFolderID];
+    newFolder.title = @"Liked";
+    newFolder.position = 1;
+    return newFolder;
 }
 
 + (IKFolder *)archiveFolder
 {
-    return [self folderWithFolderID:IKArchiveFolderID];
+    IKFolder * newFolder = [self folderWithFolderID:IKArchiveFolderID];
+    newFolder.title = @"Archive";
+    newFolder.position = 2;
+    return newFolder;
 }
 
 + (IKFolder *)folderWithFolderID:(NSInteger)folderID

--- a/Test/TestAppDelegate.m
+++ b/Test/TestAppDelegate.m
@@ -113,9 +113,9 @@
     NSLog(@"engine %@ connection %@ did verify credentials for user %@", engine, connection, user);
 }
 
-- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user
+- (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didReceiveBookmarks:(NSArray *)bookmarks ofUser:(IKUser *)user forFolder:(IKFolder *)folder
 {
-    NSLog(@"engine %@ connection %@ did receive bookmarks %@ of user %@", engine, connection, bookmarks, user);
+    NSLog(@"engine %@ connection %@ did receive bookmarks %@ of user %@ for folder %@", engine, connection, bookmarks, user, folder);
 }
 
 - (void)engine:(IKEngine *)engine connection:(IKURLConnection *)connection didUpdateReadProgressOfBookmark:(IKBookmark *)bookmark


### PR DESCRIPTION
In my usage of InstapaperKit I've found that I was using the folders created by the class methods [IKFolder unreadFolder] and so on. However, unlike folders I've pulled down from Instapaper these folders had no names or position indicators. I've updated the class methods to provide these for myself and thought I would offer them up to you.
