### PR TITLE
Fixed Description Parsing Bug

### DIFF
--- a/InstapaperKit/IKDeserializer.m
+++ b/InstapaperKit/IKDeserializer.m
@@ -121,7 +121,7 @@
             bookmark.bookmarkID    = [[self _normalizedObjectForKey:@"bookmark_id" inDictionary:dict] integerValue];
             bookmark.URL           = [self _URLForKey:@"url" inDictionary:dict];
             bookmark.title         = [self _normalizedObjectForKey:@"title" inDictionary:dict];
-            bookmark.descr         = [self _normalizedObjectForKey:@"descr" inDictionary:dict];
+            bookmark.descr         = [self _normalizedObjectForKey:@"description" inDictionary:dict];
             bookmark.date          = [self _dateForKey:@"time" inDictionary:dict];
             bookmark.starred       = [[self _normalizedObjectForKey:@"starred" inDictionary:dict] boolValue];
             bookmark.privateSource = [self _normalizedObjectForKey:@"private_source" inDictionary:dict];


### PR DESCRIPTION
We're looking into using InstapaperKit for a project here at @Lickability, and we noticed that it seems the Instapaper API has been updated to return bookmark descriptions keyed by `description` instead of `descr`. We made that change to `IKDeserializer` and started getting descriptions back.

From the [Instapaper API Documentation](http://www.instapaper.com/api/full):

``` json
 {"type":"bookmark", "bookmark_id":1234, "url":"http:\/\/www.example.com\/page1.html", "title":"Example page 1", "description":"An example page."},
 {"type":"bookmark", "bookmark_id":1235, "url":"http:\/\/www.example.com\/page2.html", "title":"Example page 2", "description":"Another example page."},
 {"type":"bookmark", "bookmark_id":1236, "url":"http:\/\/www.example.com\/page3.html", "title":"Example page 3", "description":"Yet another example page."}]
```
